### PR TITLE
[#2] Verify tests run in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/tests/unit/rollingCorrelations.test.ts
+++ b/tests/unit/rollingCorrelations.test.ts
@@ -419,7 +419,8 @@ describe("Rolling Correlations", () => {
 
       const mockData = generateMockMacroData(stockData);
 
-      expect(mockData).toHaveLength(6); // 6 indicators
+      // generateMockMacroData currently returns 16 macro indicators (6 core + 10 additional)
+      expect(mockData).toHaveLength(16);
       expect(mockData[0]).toHaveProperty("name");
       expect(mockData[0]).toHaveProperty("values");
       expect(mockData[0].values).toHaveLength(3);


### PR DESCRIPTION
Fixes #2

## What changed
- Updated rolling correlations mock-data test to match current behavior (generateMockMacroData returns 16 indicators: 6 core + 10 additional)
- Added a minimal GitHub Actions workflow to run `npm ci` + `npm test` on PRs and pushes to main

## Why
- `npm test` was failing on baseline due to outdated expectation, blocking autonomous PR generation.
- CI ensures future PRs get immediate test feedback (and matches Vercel's need for build stability).

## How tested
- `npm ci`
- `npm test` (all 116 tests passing)
- `npm run build` (Next.js build succeeded locally)

## Risk
- Low: change is isolated to a unit test expectation + adds CI workflow.

## Rollback
- Revert this PR to restore previous test expectation and remove the CI workflow.
