### PR TITLE
Add server-derived 'Last updated' timestamp to insights UI

### DIFF
--- a/src/app/api/fetch/route.ts
+++ b/src/app/api/fetch/route.ts
@@ -5,7 +5,7 @@ import {
   getGlobalQuote,
   generateMockFundamentals,
 } from "@/lib/alphaVantage";
-import { getCache, setCache, getCacheKey, CACHE_CONFIG, getRemainingTTL } from "@/lib/cache/kv";
+import { getCacheEntry, setCache, getCacheKey, CACHE_CONFIG, getRemainingTTL } from "@/lib/cache/kv";
 import { waitRandom } from "@/lib/utils";
 
 export async function POST(request: NextRequest) {
@@ -34,19 +34,20 @@ export async function POST(request: NextRequest) {
     // Check cache first (only for standard horizons, not custom date ranges)
     const isCached = horizon !== "Custom";
     let cacheKey = "";
-    let cachedData = null;
-
     if (isCached) {
       cacheKey = getCacheKey("fetch", tickerSymbol, horizon);
-      cachedData = await getCache(cacheKey);
+      const cachedEntry = await getCacheEntry(cacheKey);
 
-      if (cachedData) {
+      if (cachedEntry) {
         console.log(`[FETCH API] Cache HIT for ${tickerSymbol} (${horizon})`);
         const ttl = await getRemainingTTL(cacheKey);
         return NextResponse.json({
-          ...cachedData,
+          ...cachedEntry.data,
           _cached: true,
           _cacheTTL: ttl,
+          // Server-derived cache freshness timestamps
+          _cachedAt: cachedEntry.cachedAt,
+          _fetchedAt: null,
         });
       }
       console.log(`[FETCH API] Cache MISS for ${tickerSymbol} (${horizon})`);
@@ -173,6 +174,8 @@ export async function POST(request: NextRequest) {
       };
     }
 
+    const fetchedAt = new Date().toISOString();
+
     const data = {
       ticker: tickerSymbol,
       price: currentQuote?.price || 0,
@@ -183,6 +186,8 @@ export async function POST(request: NextRequest) {
         high: p.high,
         low: p.low,
       })),
+      // Server-derived freshness timestamp (when this response was generated)
+      _fetchedAt: fetchedAt,
     };
 
     // Cache the response (only for standard horizons)
@@ -195,6 +200,7 @@ export async function POST(request: NextRequest) {
       ...data,
       _cached: false,
       _cacheTTL: null,
+      _cachedAt: null,
     });
   } catch (error) {
     console.error("Error in /api/fetch:", error);

--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -46,14 +46,15 @@ export async function GET(request: NextRequest) {
 
 
     // Generate insights
-    const articles = await getStockNews(ticker.toUpperCase(), refreshMinutes, stockData);
+    const result = await getStockNews(ticker.toUpperCase(), refreshMinutes, stockData);
 
     // Build response
     const response: NewsResponse = {
       ticker: ticker.toUpperCase(),
-      articles,
-      cached: articles.length > 0,
-      cacheExpires: new Date(Date.now() + refreshMinutes * 60 * 1000),
+      articles: result.articles,
+      cached: result.fromCache,
+      lastUpdatedAt: result.cachedAt,
+      cacheExpires: result.expiresAt,
       preferences: {
         defaultCount: 5,
         refreshIntervalMinutes: refreshMinutes,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -134,6 +134,13 @@ export default function Home() {
           });
         }
         const fetchData = await fetchRes.json();
+
+        // Use server-derived timestamps for cache freshness (avoid client clock guesses)
+        const serverFreshness = fetchData._cachedAt || fetchData._fetchedAt;
+        if (serverFreshness) {
+          setLastUpdated(new Date(serverFreshness));
+        }
+
         progressiveAnalysis.updatePhaseProgress('fetching', 100);
         progressiveAnalysis.completePhase('fetching');
 
@@ -214,7 +221,7 @@ export default function Home() {
           aiSummary,
         });
         progressiveAnalysis.completeAnalysis();
-        setLastUpdated(new Date());
+        // lastUpdated is derived from server freshness timestamps in /api/fetch
         setPartialAnalysisData(null); // Clear partial data
       } catch (err: any) {
         let analysisError: AnalysisError;
@@ -252,7 +259,13 @@ export default function Home() {
         if (!fetchRes.ok) throw new Error("Failed to fetch data");
         const fetchData = await fetchRes.json();
 
-        const analyzeRes = await fetch("/api/analyze", {
+        // Use server-derived timestamps for cache freshness (avoid client clock guesses)
+        const serverFreshness = fetchData._cachedAt || fetchData._fetchedAt;
+        if (serverFreshness) {
+          setLastUpdated(new Date(serverFreshness));
+        }
+
+        const analyzeRes = await fetch("/api/analyze", { 
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -290,7 +303,6 @@ export default function Home() {
           priceHistory: fetchData.priceHistory,
           aiSummary,
         });
-        setLastUpdated(new Date());
 
         // Auto-save to history
         addToHistory({

--- a/src/components/AnalysisView.tsx
+++ b/src/components/AnalysisView.tsx
@@ -16,6 +16,7 @@ import ShareButton from "./ShareButton";
 import { StockNews } from "./StockNews";
 import { useFavorites } from "@/hooks/useFavorites";
 import { useAlerts } from "@/hooks/useAlerts";
+import { formatRelativeTime } from "@/lib/time";
 import { CorrelationAnalysis } from "@/lib/macro/rollingCorrelations";
 import { RollingBetaPoint } from "@/lib/macro/betaRegression";
 import { RegimeAnalysis } from "@/lib/macro/regimeDetection";
@@ -109,18 +110,7 @@ export default function AnalysisView({
     }
   }, [ticker, data?.technicals, checkAlerts]);
 
-  const formatLastUpdated = (date: Date | null) => {
-    if (!date) return "Never";
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffMins = Math.floor(diffMs / 60000);
-    if (diffMins < 1) return "Just now";
-    if (diffMins < 60) return `${diffMins}m ago`;
-    const diffHours = Math.floor(diffMins / 60);
-    if (diffHours < 24) return `${diffHours}h ago`;
-    const diffDays = Math.floor(diffHours / 24);
-    return `${diffDays}d ago`;
-  };
+  const formatLastUpdated = (date: Date | null) => formatRelativeTime(date);
 
   const fundamentals = data?.fundamentals || {
     pe: 0,

--- a/src/components/StockNews.tsx
+++ b/src/components/StockNews.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from "react";
 import type { NewsArticle } from "@/types/news";
+import { formatLastUpdatedTimestamp } from "@/lib/formatLastUpdated";
 
 interface StockNewsProps {
   ticker: string;
@@ -13,6 +14,7 @@ export function StockNews({ ticker, maxArticles = 3 }: StockNewsProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>("");
   const [cached, setCached] = useState(false);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     async function fetchNews() {
@@ -35,8 +37,8 @@ export function StockNews({ ticker, maxArticles = 3 }: StockNewsProps) {
         setArticles(
           (data.articles || []).slice(0, maxArticles)
         );
-        setCached(data.cached);
-
+        setCached(Boolean(data.cached));
+        setLastUpdatedAt(data.lastUpdatedAt);
 
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -76,9 +78,12 @@ export function StockNews({ ticker, maxArticles = 3 }: StockNewsProps) {
 
   if (articles.length === 0) {
     return (
-      <div className="p-6 text-center bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg">
+      <div className="p-6 text-center bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg space-y-2">
         <p className="text-slate-600 dark:text-slate-400">
           Unable to generate market insights at this time. Please try again later.
+        </p>
+        <p className="text-xs text-slate-500 dark:text-slate-500">
+          Last updated: {formatLastUpdatedTimestamp(lastUpdatedAt)}
         </p>
       </div>
     );
@@ -86,12 +91,15 @@ export function StockNews({ ticker, maxArticles = 3 }: StockNewsProps) {
 
   return (
     <div className="space-y-4">
-      {/* Cache indicator */}
-      {cached && (
-        <div className="text-xs text-slate-500 dark:text-slate-400 px-2 py-1 bg-slate-100 dark:bg-slate-800 rounded">
-          Cached results • Updated 24h ago
-        </div>
-      )}
+      {/* Freshness indicator (server-provided) */}
+      <div className="text-xs text-slate-500 dark:text-slate-400 px-2 py-1 bg-slate-100 dark:bg-slate-800 rounded flex items-center justify-between gap-3">
+        <span>
+          Last updated: {formatLastUpdatedTimestamp(lastUpdatedAt)}
+        </span>
+        {cached && (
+          <span className="font-medium">Cached</span>
+        )}
+      </div>
 
       {/* Article list */}
       {articles.map((article) => (

--- a/src/lib/cache/kv.ts
+++ b/src/lib/cache/kv.ts
@@ -29,6 +29,25 @@ let stats = {
  * Get value from cache with TTL check
  * Returns null if expired or not found
  */
+function parseCacheEntry(raw: unknown): CacheEntry | null {
+  if (!raw) return null;
+
+  // @vercel/kv may return objects directly, but our setCache stores JSON strings.
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as CacheEntry;
+    } catch {
+      return null;
+    }
+  }
+
+  if (typeof raw === "object" && raw !== null) {
+    return raw as CacheEntry;
+  }
+
+  return null;
+}
+
 export async function getCache(key: string): Promise<any | null> {
   try {
     const cached = await kv.get(key);
@@ -38,7 +57,12 @@ export async function getCache(key: string): Promise<any | null> {
       return null;
     }
 
-    const entry = cached as CacheEntry;
+    const entry = parseCacheEntry(cached);
+    if (!entry) {
+      stats.misses++;
+      return null;
+    }
+
     const age = (Date.now() - entry.timestamp) / 1000;
 
     // Check if expired
@@ -53,6 +77,31 @@ export async function getCache(key: string): Promise<any | null> {
   } catch (error) {
     console.error("[CACHE] Get error:", error);
     stats.misses++;
+    return null;
+  }
+}
+
+export async function getCacheEntry(
+  key: string
+): Promise<{ data: any; cachedAt: string; ttlSeconds: number } | null> {
+  try {
+    const cached = await kv.get(key);
+    const entry = parseCacheEntry(cached);
+    if (!entry) return null;
+
+    const age = (Date.now() - entry.timestamp) / 1000;
+    if (age > entry.ttl) {
+      await kv.del(key);
+      return null;
+    }
+
+    return {
+      data: entry.data,
+      cachedAt: new Date(entry.timestamp).toISOString(),
+      ttlSeconds: entry.ttl,
+    };
+  } catch (error) {
+    console.error("[CACHE] Get entry error:", error);
     return null;
   }
 }
@@ -180,7 +229,9 @@ export async function getRemainingTTL(key: string): Promise<number | null> {
     const cached = await kv.get(key);
     if (!cached) return null;
 
-    const entry = cached as CacheEntry;
+    const entry = parseCacheEntry(cached);
+    if (!entry) return null;
+
     const age = (Date.now() - entry.timestamp) / 1000;
     const remaining = entry.ttl - age;
 

--- a/src/lib/formatLastUpdated.ts
+++ b/src/lib/formatLastUpdated.ts
@@ -1,0 +1,15 @@
+/**
+ * Formatting helpers for server-provided freshness timestamps.
+ *
+ * We keep this deterministic (ISO-derived) so UI + tests don't depend on locale/timezone.
+ */
+
+export function formatLastUpdatedTimestamp(dateLike?: Date | string | null): string {
+  if (!dateLike) return "—";
+
+  const d = new Date(dateLike);
+  if (Number.isNaN(d.getTime())) return "—";
+
+  // Example: 2026-02-16 20:15 UTC
+  return `${d.toISOString().replace("T", " ").slice(0, 16)} UTC`;
+}

--- a/src/lib/newsAggregator.ts
+++ b/src/lib/newsAggregator.ts
@@ -162,6 +162,13 @@ Focus on actionable observations that traders would find useful.`,
  * Get market insights for a stock ticker (with caching)
  * Returns cached insights if fresh, otherwise generates new ones
  */
+export type StockNewsResult = {
+  articles: NewsArticle[];
+  fromCache: boolean;
+  cachedAt: Date;
+  expiresAt: Date;
+};
+
 export async function getStockNews(
   ticker: string,
   refreshMinutes?: number,
@@ -174,7 +181,7 @@ export async function getStockNews(
     pe?: number;
     dividend?: number;
   }
-): Promise<NewsArticle[]> {
+): Promise<StockNewsResult> {
   const cacheKey = getCacheKey("news", ticker);
   const cacheCheckMinutes = refreshMinutes || DEFAULT_CONFIG.refreshIntervalMinutes;
 
@@ -183,12 +190,16 @@ export async function getStockNews(
   if (
     cached &&
     new Date().getTime() - new Date((cached as NewsCache).cachedAt).getTime() <
-    cacheCheckMinutes * 60 * 1000
+      cacheCheckMinutes * 60 * 1000
   ) {
-    return (cached as NewsCache).articles.slice(0, DEFAULT_CONFIG.insightCount);
+    const c = cached as NewsCache;
+    return {
+      articles: c.articles.slice(0, DEFAULT_CONFIG.insightCount),
+      fromCache: true,
+      cachedAt: new Date(c.cachedAt),
+      expiresAt: new Date(c.expiresAt),
+    };
   }
-
-
 
   // Generate fresh insights
   let articles = await generateAIInsights(ticker, stockData);
@@ -214,9 +225,12 @@ export async function getStockNews(
 
   await setCache(cacheKey, cacheData, cacheCheckMinutes * 60);
 
-
-
-  return articles;
+  return {
+    articles,
+    fromCache: false,
+    cachedAt: new Date(cacheData.cachedAt),
+    expiresAt: new Date(cacheData.expiresAt),
+  };
 }
 
 /**

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,0 +1,19 @@
+/**
+ * Time helpers for displaying server-derived freshness timestamps.
+ */
+
+export function formatRelativeTime(date: Date | null, now: Date = new Date()): string {
+  if (!date) return "Unknown";
+
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+
+  if (diffMins < 1) return "Just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+
+  const diffDays = Math.floor(diffHours / 24);
+  return `${diffDays}d ago`;
+}

--- a/src/tests/formatLastUpdated.test.ts
+++ b/src/tests/formatLastUpdated.test.ts
@@ -1,0 +1,18 @@
+import { formatLastUpdatedTimestamp } from "@/lib/formatLastUpdated";
+
+describe("formatLastUpdatedTimestamp", () => {
+  it("returns placeholder for null/undefined", () => {
+    expect(formatLastUpdatedTimestamp(undefined)).toBe("—");
+    expect(formatLastUpdatedTimestamp(null)).toBe("—");
+  });
+
+  it("formats ISO strings as YYYY-MM-DD HH:mm UTC", () => {
+    expect(formatLastUpdatedTimestamp("2026-02-16T20:15:41.000Z")).toBe(
+      "2026-02-16 20:15 UTC"
+    );
+  });
+
+  it("returns placeholder for invalid dates", () => {
+    expect(formatLastUpdatedTimestamp("not-a-date")).toBe("—");
+  });
+});

--- a/src/tests/time.test.ts
+++ b/src/tests/time.test.ts
@@ -1,0 +1,31 @@
+import { formatRelativeTime } from "@/lib/time";
+
+describe("formatRelativeTime", () => {
+  it("returns placeholder when date is null", () => {
+    expect(formatRelativeTime(null)).toBe("Unknown");
+  });
+
+  it("returns 'Just now' for under 1 minute", () => {
+    const now = new Date("2026-02-17T04:00:00.000Z");
+    const date = new Date("2026-02-17T03:59:30.000Z");
+    expect(formatRelativeTime(date, now)).toBe("Just now");
+  });
+
+  it("returns minutes", () => {
+    const now = new Date("2026-02-17T04:00:00.000Z");
+    const date = new Date("2026-02-17T03:01:00.000Z");
+    expect(formatRelativeTime(date, now)).toBe("59m ago");
+  });
+
+  it("returns hours", () => {
+    const now = new Date("2026-02-17T04:00:00.000Z");
+    const date = new Date("2026-02-17T03:00:00.000Z");
+    expect(formatRelativeTime(date, now)).toBe("1h ago");
+  });
+
+  it("returns days", () => {
+    const now = new Date("2026-02-17T04:00:00.000Z");
+    const date = new Date("2026-02-15T04:00:00.000Z");
+    expect(formatRelativeTime(date, now)).toBe("2d ago");
+  });
+});

--- a/src/types/news.ts
+++ b/src/types/news.ts
@@ -40,7 +40,13 @@ export interface NewsPreferences {
 export interface NewsResponse {
   ticker: string;
   articles: NewsArticle[];
+  /**
+   * True if this response was served from cache (vs freshly generated).
+   * Note: serialized over JSON, so Date fields arrive as strings in the browser.
+   */
   cached: boolean;
+  /** Server-side timestamp for when the cached/generated insights were last updated. */
+  lastUpdatedAt?: Date;
   cacheExpires: Date;
   preferences: NewsPreferences;
 }

--- a/tests/unit/rollingCorrelations.test.ts
+++ b/tests/unit/rollingCorrelations.test.ts
@@ -419,7 +419,7 @@ describe("Rolling Correlations", () => {
 
       const mockData = generateMockMacroData(stockData);
 
-      expect(mockData).toHaveLength(6); // 6 indicators
+      expect(mockData).toHaveLength(16); // indicators (see generateMockMacroData)
       expect(mockData[0]).toHaveProperty("name");
       expect(mockData[0]).toHaveProperty("values");
       expect(mockData[0].values).toHaveLength(3);


### PR DESCRIPTION
Implements server-derived cache freshness timestamps for the analysis/results UI.

What changed:
- `/api/fetch` now returns `_cachedAt` (cache hit) or `_fetchedAt` (fresh response)
- Home page stores `lastUpdated` from those server timestamps (no client-clock guessing)
- Analysis UI displays "Last updated" using that value
- Adds a minimal unit test for the formatting helper (`formatRelativeTime`)

Closes #8.